### PR TITLE
Changed to skip subscription before client is started.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "repository": "logux/react-logux",
   "peerDependencies": {
     "logux-redux": "^0.1.1",
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0",
+    "react-redux": "^5.0.6"
   },
   "devDependencies": {
     "create-react-class": "^15.6.2",


### PR DESCRIPTION
### Reason
The https://github.com/logux/logux-redux/pull/4 pull request deferred the start of logux client.

After that we may have case a subscribed react component adding log before client is configured.

### Implementation
The current implementation may not be desired. I have added react-redux as dependency, and make use of connect to get the logux state from logux-reducer (from the logux-redux patch above).

Since the name is hardcoded as logux, which might not be good way to do.